### PR TITLE
Forget with tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All Notable changes to `spatie/laravel-partialcache` will be documented in this file
 
+## 1.2.3
+- Supports forget with tags
+
 ## 1.2.2 - 2018-02-13
 - Add autoregister
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ You can forget a partialcache entry with `PartialCache::forget($view, $key)`.
 ```php
 PartialCache::forget('user.profile', $user->id);
 ```
+If you have used @cache on an entry along with tags and your cache driver supports them (like memcached and other), you need to use the same tags to forget the entry.
+
+```php
+// With an added tag
+PartialCache::forget('user.profile', $user->id, 'userprofiles');
+
+// With array of tags
+PartialCache::forget('user.profile', $user->id, ['user', 'profile', 'location']);
+```
 
 If you want to flush all entries, you'll need to either call `PartialCache::flush()` (note: this is only supported by drivers that support tags), or clear your entire cache.
 
@@ -115,7 +124,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/src/PartialCache.php
+++ b/src/PartialCache.php
@@ -80,15 +80,7 @@ class PartialCache
 
         $mergeData = $mergeData ?: [];
 
-        $tags = [$this->cacheKey];
-
-        if ($tag) {
-            if (!is_array($tag)) {
-                $tag = [$tag];
-            }
-
-            $tags = array_merge($tags, $tag);
-        }
+        $tags = $this->getTags($tag);
 
         if ($this->cacheIsTaggable && $minutes === null) {
             return $this->cache
@@ -135,13 +127,15 @@ class PartialCache
      *
      * @param string $view
      * @param string $key
+     * @param null|string|array $tag
      */
-    public function forget($view, $key = null)
+    public function forget($view, $key = null, $tag = null)
     {
         $cacheKey = $this->getCacheKeyForView($view, $key);
 
         if ($this->cacheIsTaggable) {
-            $this->cache->tags($this->cacheKey)->forget($cacheKey);
+            $tags = $this->getTags($tag);
+            $this->cache->tags($tags)->forget($cacheKey);
         }
 
         $this->cache->forget($cacheKey);
@@ -183,5 +177,27 @@ class PartialCache
         return function () use ($view, $data, $mergeData) {
             return $this->view->make($view, $data, $mergeData)->render();
         };
+    }
+
+    /**
+     * Constructs tag array
+     *
+     * @param null|string|array $tag
+     *
+     * @return array
+     */
+    protected function getTags($tag = null)
+    {
+        $tags = [$this->cacheKey];
+
+        if ($tag) {
+            if (!is_array($tag)) {
+                $tag = [$tag];
+            }
+
+            $tags = array_merge($tags, $tag);
+        }
+
+        return $tags;
     }
 }


### PR DESCRIPTION
Hi,

Thanks for this package, it's really useful.

If you are using a [TaggableStore](https://laravel.com/api/5.5/Illuminate/Cache/TaggableStore.html) cache in your project, you may cache an entry with tags like the fllowing:

`@cache('user.profile', null, null, $user->id, ['user', 'profile', 'location'])`

Later on, if you want to forget the entry, you want to use:

`PartialCache::forget('user.profile', $user->id);`

But this call won't work because the entry has been tagged. You need to use the same tags (with the same order as cached) to achieve forget on the specific entry. So the call needs to be like:

`PartialCache::forget('user.profile', $user->id, ['user', 'profile', 'location']);`

This PR contains a fix on the forget method to allow for the user to enter tags. I have moved the tag array construction from `PartialCache::cache` method to a new `PartialCache::getTags` method which is used by both `PartialCache::cache` and `PartialCache::forget` methods.

Hope it helps.